### PR TITLE
Fix Traceback for Dexterity Types

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,10 @@
+1.1.0 (unreleased)
+------------------
+
+- #10 Fix Traceback for Dexterity Types
+
+
+
 1.0.0 (2020-09-22)
 ------------------
 

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -47,6 +47,7 @@ from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.component import queryUtility
 from zope.interface import alsoProvides
+from zope.schema.interfaces import IField
 from zope.schema.interfaces import IVocabularyFactory
 
 DEFAULT_REF = "title"
@@ -278,6 +279,13 @@ class DataBoxView(ListingView):
         """Checks if the field is a reference field type
         """
         if not field:
+            return False
+        if IField.providedBy(field):
+            # TODO: At the moment we do not have a dexterity based reference
+            #       field. Implement this when we have an interface for this.
+            return False
+        field_type = getattr(field, "type", None)
+        if field_type is None:
             return False
         return field.type in REF_FIELD_TYPES
 

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -51,7 +51,7 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import IVocabularyFactory
 
 DEFAULT_REF = "title"
-REF_FIELD_TYPES = ["reference"]
+REF_FIELD_TYPES = ["reference", "uidreference"]
 
 
 class DataBoxView(ListingView):


### PR DESCRIPTION
## Description

This PR fixes an error when a Dexterity type is selected for a DataBox:

Note: Since we do not have a specific reference field implementation for Dexterity fields, we assume here that all fields are non-reference fields. As soon as we have this reference field implemented, we need to address this issue here once again.

## Traceback

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 220, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 192, in render
  Module 66a1fd14896f8a169fc38d68c65be92a, line 301, in render
  Module d810d646b45ec612cb9dec18a75f023d, line 1449, in render_master
  Module d810d646b45ec612cb9dec18a75f023d, line 407, in render_content
  Module 66a1fd14896f8a169fc38d68c65be92a, line 168, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 196, in _eval
  Module Products.PageTemplates.Expressions, line 126, in render
  Module senaite.databox.browser.view, line 95, in render_databox_controls
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module db300d90eca33d2b2670afd42bc6a922, line 1611, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.get_reference_columns(column))
  Module <string>, line 1, in <module>
  Module senaite.databox.browser.view, line 319, in get_reference_columns
  Module senaite.databox.browser.view, line 282, in is_reference_field
AttributeError: 'TextLine' object has no attribute 'type'
```