### PR TITLE
Remove orphane reference columns

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.1.0 (unreleased)
 ------------------
 
+- #12 Remove orphane reference columns
 - #11 Fix error when the column "SampleType" was selected #11
 - #10 Fix Traceback for Dexterity Types
 

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -356,6 +356,10 @@ class DataBoxView(ListingView):
             ref_type = self.get_reftype(field)
             ref_fields = self.databox.get_fields(portal_type=ref_type)
 
+            # not a reference anymore, break
+            if not ref_type:
+                break
+
             if num == len(refs) - 1:
                 if self.is_reference_field(field):
                     ref_type = self.get_reftype(field)


### PR DESCRIPTION
## Description

This PR removes orphan reference columns definitions.
This happens when a previous reference column, e.g. `SampleType` was changed to a non-reference column, e.g. `SampleTypeTitle`. In this case, an additional column remained with the fields from `SampleType`.