### PR TITLE
Reduce conflict errors when creating temporary objects

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.1.0 (unreleased)
 ------------------
 
+- #14 Reduce conflict errors when creating temporary objects
 - #12 Remove orphane reference columns
 - #11 Fix error when the column "SampleType" was selected #11
 - #10 Fix Traceback for Dexterity Types

--- a/src/senaite/databox/behaviors/databox.py
+++ b/src/senaite/databox/behaviors/databox.py
@@ -22,6 +22,7 @@ import ast
 from copy import copy
 from datetime import datetime
 
+import transaction
 from bika.lims import api
 from DateTime import DateTime
 from dateutil import parser
@@ -233,6 +234,7 @@ class DataBox(object):
         # reduce conflict errors
         portal_factory._p_jar.sync()
         temp_folder.invokeFactory(portal_type, id=portal_type)
+        transaction.commit()
         return temp_folder[portal_type]
 
     def get_query_catalog(self, default="portal_catalog"):

--- a/src/senaite/databox/behaviors/databox.py
+++ b/src/senaite/databox/behaviors/databox.py
@@ -230,6 +230,8 @@ class DataBox(object):
         temp_folder = portal_factory._getTempFolder(TMP_FOLDER_KEY)
         if portal_type in temp_folder:
             return temp_folder[portal_type]
+        # reduce conflict errors
+        portal_factory._p_jar.sync()
         temp_folder.invokeFactory(portal_type, id=portal_type)
         return temp_folder[portal_type]
 


### PR DESCRIPTION
## Description

Database conflicts in a non-reproducable manner:

database conflict error (oid 0x0239cc, class Products.CMFCore.TypesTool.FactoryTypeInformation, serial this txn started with 0x03dc8087c5ae5900 2020-12-07 19:51:46.331495, serial currently committed 0x03dc80885662c266 2020-12-07 19:52:20.246667)

This PR tries to minimize them.