### PR TITLE
Fix UnicodeEncodeError when exporting via CSV

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.1.0 (unreleased)
 ------------------
 
+- #21 Fix UnicodeEncodeError when exporting via CSV
 - #20 Allow to retrieve column value with a Python expression
 - #19 Fix columns and active-tab handling
 - #17 Fix selection of non-sortable indexes

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -160,7 +160,9 @@ class DataBoxView(ListingView):
 
         # write the rows as CSV
         for row in self.get_rows():
-            writer.writerow(row)
+            def to_utf8(s):
+                return api.safe_unicode(s).encode("utf8")
+            writer.writerow(map(to_utf8, row))
 
         return csvfile.getvalue()
 


### PR DESCRIPTION
## Description

This PR fixes a `UnicodeEncodeError` when exporting via CSV

## Traceback

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.databox.browser.view, line 121, in export_to_csv
  Module senaite.databox.browser.view, line 163, in get_csv
UnicodeEncodeError: 'ascii' codec can't encode characters in position 14-16: ordinal not in range(128)
```