### PR TITLE
Fix traceback for DX types that are not globally allowed

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #23 Fix traceback for DX types that are not globally allowed
 
 
 1.1.0 (2022-01-05)


### PR DESCRIPTION
## Description

This PR fixes a traceback when creating a databox for DX types that are not globally allowed.