### PR TITLE
Fix TypeError when setting allowed types

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.0 (unreleased)
 ------------------
 
+- #25 Fix TypeError when setting allowed types
 - #24 Added custom DataBox workflows
 - #23 Fix traceback for DX types that are not globally allowed
 

--- a/src/senaite/databox/behaviors/databox.py
+++ b/src/senaite/databox/behaviors/databox.py
@@ -229,7 +229,10 @@ class DataBox(object):
         # get the current allowed types for the object
         allowed_types = fti.allowed_content_types
         # append the allowed type
-        fti.allowed_content_types = allowed_types + [allowed_type, ]
+        if isinstance(allowed_types, tuple):
+            fti.allowed_content_types = allowed_types + (allowed_type, )
+        else:
+            fti.allowed_content_types = allowed_types + [allowed_type, ]
 
         yield obj
 


### PR DESCRIPTION
## Description

This PR fixes a traceback that occurs for imported sites.

Traceback:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 229, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 3f2c84ccee10324838f962889254b529, line 301, in render
  Module 4ef9836b564df2860c682a1f90af0993, line 1449, in render_master
  Module 4ef9836b564df2860c682a1f90af0993, line 407, in render_content
  Module 3f2c84ccee10324838f962889254b529, line 168, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module senaite.databox.browser.view, line 96, in render_databox_controls
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module fe992599a09a8bce52c2167b611fae27, line 1702, in render
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module plone.memoize.view, line 59, in memogetter
  Module senaite.databox.browser.view, line 249, in get_schema_fields
  Module senaite.databox.behaviors.databox, line 182, in get_fields
  Module senaite.databox.behaviors.databox, line 256, in _create_temporary_object
  Module contextlib, line 17, in __enter__
  Module senaite.databox.behaviors.databox, line 234, in temporary_allow_type
TypeError: can only concatenate tuple (not "list") to tuple
```