### PR TITLE
Remove dependency to Products.TextIndexNG3 (test layer)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.3.0 (unreleased)
 ------------------
 
-- no changes yet
+- #26 Remove dependency to Products.TextIndexNG3 (test layer)
 
 
 1.2.0 (2022-06-10)

--- a/src/senaite/databox/tests/layers.py
+++ b/src/senaite/databox/tests/layers.py
@@ -39,7 +39,6 @@ class BaseLayer(PloneSandboxLayer):
         super(BaseLayer, self).setUpZope(app, configurationContext)
 
         # Load ZCML
-        import Products.TextIndexNG3
         import bika.lims
         import senaite.core
         import senaite.app.listing
@@ -48,7 +47,6 @@ class BaseLayer(PloneSandboxLayer):
         import senaite.impress
         import senaite.lims
 
-        self.loadZCML(package=Products.TextIndexNG3)
         self.loadZCML(package=bika.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
@@ -58,7 +56,6 @@ class BaseLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.lims)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "Products.TextIndexNG3")
         zope.installProduct(app, "bika.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the `Products.TextIndexNG3` dependency on the test layer because it is no longer a SENAITE dependency as per https://github.com/senaite/senaite.core/pull/2011 and https://github.com/senaite/senaite.core/pull/2014