### PR TITLE
Fix title encoding error when generating XLS worksheets

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.4.0 (unreleased)
 ------------------
 
-- no changes yet
+- #29 Fix title encoding error when generating XLS worksheets
 
 
 1.3.0 (2023-03-10)

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -171,7 +171,7 @@ class DataBoxView(ListingView):
         """
         workbook = Workbook()
         first_sheet = workbook.get_active_sheet()
-        first_sheet.title = self.context.Title().decode('utf-8')
+        first_sheet.title = api.safe_unicode(self.context.Title())
         for row in self.get_rows():
             first_sheet.append(row)
         return save_virtual_workbook(workbook)

--- a/src/senaite/databox/browser/view.py
+++ b/src/senaite/databox/browser/view.py
@@ -171,7 +171,7 @@ class DataBoxView(ListingView):
         """
         workbook = Workbook()
         first_sheet = workbook.get_active_sheet()
-        first_sheet.title = self.context.Title()
+        first_sheet.title = self.context.Title().decode('utf-8')
         for row in self.get_rows():
             first_sheet.append(row)
         return save_virtual_workbook(workbook)


### PR DESCRIPTION
this  nanofix lets use non-english names for XLS-sheets. Otherwise it fails to generate XLS-file with follow traceback:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.databox.browser.view, line 129, in export_to_excel
  Module senaite.databox.browser.view, line 174, in get_excel
  Module openpyxl.workbook.child, line 91, in title
ValueError: Worksheet titles must be unicode
```