### PR TITLE
Fix catalog lookup for DX types

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.4.0 (unreleased)
 ------------------
 
+- #30 Fix catalog lookup for DX types
 - #29 Fix title encoding error when generating XLS worksheets
 
 

--- a/src/senaite/databox/config.py
+++ b/src/senaite/databox/config.py
@@ -24,6 +24,8 @@ TMP_FOLDER_KEY = "senaite.databox.tmp"
 
 DATE_INDEX_TYPES = ["DateIndex"]
 
+UID_CATALOG = "uid_catalog"
+
 PARENT_TYPES = {
     "Analysis": "AnalysisRequest",
     "AnalysisRequest": "Client",


### PR DESCRIPTION
## Description

This PR fixes `senaite.databox` to find the right catalog for Dexterity based contents.

## Current Behavior

Databoxes that query Dexterity based contents use `portal_catalog` catalog for query

## Desired Behavior

Databoxes that query Dexterity based contents use the first catalog of the `_catalogs` class attribute as the primary catalog.