### PR TITLE
Compatibility with core#2584 (SampleType to DX)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.5.0 (unreleased)
 ------------------
 
+- #37 Compatibility with core#2584 (SampleType to DX)
 - #36 Compatibility with core#2567 (AnalysisCategory to DX)
 - #33 Fix date issues when user inputs: date out of bound or date_to earlier than date_from
 - #35 Allow to query Auto Import Log type

--- a/src/senaite/databox/tests/doctests/Databox.rst
+++ b/src/senaite/databox/tests/doctests/Databox.rst
@@ -91,8 +91,8 @@ Setup the Lab for testing:
     >>> labcontact1 = api.create(labcontacts, "LabContact", Firstname="Lab", Lastname="Contact 1")
     >>> labcontact2 = api.create(labcontacts, "LabContact", Firstname="Lab", Lastname="Contact 2")
 
-    >>> sampletype1 = api.create(bikasetup.bika_sampletypes, "SampleType", title="Metals", Prefix="Metals")
-    >>> sampletype2 = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="Water")
+    >>> sampletype1 = api.create(setup.sampletypes, "SampleType", title="Metals", Prefix="Metals")
+    >>> sampletype2 = api.create(setup.sampletypes, "SampleType", title="Water", Prefix="Water")
 
     >>> department1 = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact1)
     >>> department2 = api.create(setup.departments, "Department", title="Microbiology", Manager=labcontact2)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!WARNING]  
> Merge https://github.com/senaite/senaite.core/pull/2584 first

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2584


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html